### PR TITLE
Mysqlfix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,11 @@ services:
   db:
     image: mysql:8.0
     platform: linux/amd64
+    #コマンド記入一変更、lower_case追記
+    command: "mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --lower_case_table_names=1"
+    #volume名変更 mysql/data => mysql_data
     volumes:
-      - ./mysql/data:/var/lib/mysql
+      - mysql_data:/var/lib/mysql
     ports:
       - 3306:3306
     environment:
@@ -50,4 +53,7 @@ services:
       MYSQL_USER: django
       MYSQL_PASSWORD: django
       TZ: 'Asia/Tokyo'
-    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci
+      
+#追記
+volumes:
+  mysql_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,9 +40,7 @@ services:
   db:
     image: mysql:8.0
     platform: linux/amd64
-    #コマンド記入一変更、lower_case追記
-    command: "mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --lower_case_table_names=1"
-    #volume名変更 mysql/data => mysql_data
+    #マウント方式、volume名変更 ./mysql/data => mysql_data
     volumes:
       - mysql_data:/var/lib/mysql
     ports:
@@ -53,7 +51,8 @@ services:
       MYSQL_USER: django
       MYSQL_PASSWORD: django
       TZ: 'Asia/Tokyo'
-      
+    #コマンドlower_case, 追記
+    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci --lower_case_table_names=1
 #追記
 volumes:
   mysql_data:


### PR DESCRIPTION
Dockerのdbコンテナが立ち上がった直後に初期化エラーでexitしてしまうのを解消するための変更提案です(Windows11,WSL2で動作確認しました)